### PR TITLE
fix typo: missing char

### DIFF
--- a/kubectl-ssh-jump
+++ b/kubectl-ssh-jump
@@ -187,7 +187,7 @@ plugin_main() {
 	;;
       "-a" | "--args" )
 	sshargs="$2"
-	nSkRip=2
+	nSkip=2
 	;;
       [a-z]*)
 	destnode=$1


### PR DESCRIPTION
Many thank's Yokawasa to accepting my PR.
I feel ashamed to say that I missed a mistake.
I forgot one mode char in arg option, =s.
Sorry for this. 

Regards