### PR TITLE
Fix to address pod sshjump pod scheduling on hybrid clusters

### DIFF
--- a/kubectl-ssh-jump
+++ b/kubectl-ssh-jump
@@ -128,7 +128,24 @@ run_ssh_node(){
   r=$(kubectl get pod sshjump 2>/dev/null | tail -1 | awk '{print $1}') # 
   if [ "${r}" != "sshjump" ];then
     echo "Creating SSH jump host (Pod)..."
-    kubectl run sshjump --image=corbinu/ssh-server --port=22 --restart=Never
+    cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sshjump
+  labels:
+    env: test
+spec:
+  containers:
+  - name: sshjump
+    image: corbinu/ssh-server
+    ports:
+    - containerPort: 22
+  nodeSelector:
+    "kubernetes.io/os": linux
+EOF
+
+    #kubectl run sshjump --image=corbinu/ssh-server --port=22 --restart=Never
     # Wait until sshjump gets ready
     c=1
     while [[ ${c} -le ${MAX_POD_CREATION_TIME} ]];

--- a/kubectl-ssh-jump
+++ b/kubectl-ssh-jump
@@ -145,7 +145,6 @@ spec:
     "kubernetes.io/os": linux
 EOF
 
-    #kubectl run sshjump --image=corbinu/ssh-server --port=22 --restart=Never
     # Wait until sshjump gets ready
     c=1
     while [[ ${c} -le ${MAX_POD_CREATION_TIME} ]];


### PR DESCRIPTION
FIx for issue #4 

Update the 'kubectl run' command with a manifest including a nodeselector for linux.